### PR TITLE
added data export pane

### DIFF
--- a/rtrack/templates/rtrack/reportview.html
+++ b/rtrack/templates/rtrack/reportview.html
@@ -114,6 +114,7 @@
                 <button type="submit" class="btn btn-primary" id="user-account-modal-save">Add User</button>
             </div>
         </form>
+
     {% if userlinkdata %}
         <!-- <p>Associated Accounts  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#add-account-modal">Add account</button></p> -->
 
@@ -165,6 +166,54 @@
     {% else %}
         <p>No notes associated with this report.  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#add-note-modal">Add Note</button></p>
     {% endif %}
+    </div>
+</div>
+
+<div class="panel panel-default">
+    <div class="panel-body">
+        <p>Export data</p>
+
+
+    <button id="togglereport" name="Show report">Show report</button>
+    <button id="sendtoadmins">Send report to the admins</button>
+    <textarea cols="60" rows="10" class="form-control" type="text" id="copypaste" name="copypaste" style="display:none;"></textarea>
+    <script type="text/javascript">
+
+    var body = "Recent usernames:\n";
+    {% for udata in userlinkdatafiltered %}
+        body += "\n- /u/{{ udata.name }}";
+    {% endfor %}
+    body += "\n\nRecent URLs:\n"
+    {% for urldata in urllinkdatafiltered %}
+        body += "\n- {{ urldata.url }}";
+    {% endfor %}
+
+    $("#copypaste").text(body);
+    $(document).ready(function() {
+        $("#togglereport").click( function(){
+            if($("#copypaste").css("display")=="none") {
+                $("#copypaste").css("display", "unset");
+                $("#togglereport").text("Hide report");
+                $('html, body').scrollTop( $(document).height() - $(window).height() );
+            } else {
+                $("#copypaste").css("display", "none");
+                $("#togglereport").text("Show report");
+            }
+        });
+    });
+    $(document).ready(function() {
+        $("#sendtoadmins").click( function(){
+           var baseUrl = "https://www.reddit.com/message/compose?to=/r/reddit.com&message=";
+           baseUrl += encodeURIComponent($("#copypaste").val());
+           var win = window.open(baseUrl, '_blank');
+           if (win) {
+               win.focus();
+           } else {
+               alert('Please allow popups for this website');
+           }
+        });
+    });
+    </script>
     </div>
 </div>
 

--- a/rtrack/views.py
+++ b/rtrack/views.py
@@ -29,11 +29,15 @@ def reportview(request, report_id):
     userlinkdata = UserReportLink.objects.filter(report=report_id)
     urllinkdata = UrlReportLink.objects.filter(report=report_id)
     notelinkdata = NoteReportLink.objects.filter(report=report_id)
+    urllinkdatafiltered = UrlReportLink.objects.filter(report=report_id).order_by('-timestamp')[:5]
+    userlinkdatafiltered = UserReportLink.objects.filter(report=report_id).order_by('-timestamp')[:5]
 
     context = {'report_data': report_data,
                'userlinkdata': userlinkdata,
                'urllinkdata': urllinkdata,
                'notelinkdata': notelinkdata,
+               'urllinkdatafiltered': urllinkdatafiltered,
+               'userlinkdatafiltered': userlinkdatafiltered,
                }
 
     return render(request, 'rtrack/reportview.html', context)


### PR DESCRIPTION
This adds a copy/paste view of data for a report, as well as a link to send the report to /r/reddit.com (the admins). The 5 most recent users and links associated with a report are included in the export. In addition to the read-only view presently available, this should resolve #35.

![nimbus-record-video](https://cloud.githubusercontent.com/assets/10442214/21070981/c19688da-be57-11e6-8297-eeaee1835400.gif)
